### PR TITLE
Update content admin templates context

### DIFF
--- a/src/Admin/ActionListener/ContentVersion/TranslationsListener.php
+++ b/src/Admin/ActionListener/ContentVersion/TranslationsListener.php
@@ -10,7 +10,7 @@ use Softspring\CmsBundle\Manager\ContentVersionManagerInterface;
 use Softspring\CmsBundle\Manager\RouteManagerInterface;
 use Softspring\CmsBundle\Model\ContentInterface;
 use Softspring\CmsBundle\Model\ContentVersionInterface;
-use Softspring\CmsBundle\Render\RenderErrorException;
+use Softspring\CmsBundle\Render\Error\RenderErrorException;
 use Softspring\CmsBundle\Request\FlashNotifier;
 use Softspring\CmsBundle\Translator\TranslatableContext;
 use Softspring\CmsTranslationPlugin\SfsCmsTranslationPlugin;

--- a/src/Translator/TranslatorExtractor.php
+++ b/src/Translator/TranslatorExtractor.php
@@ -89,7 +89,7 @@ class TranslatorExtractor
             $seo = $version->getSeo();
             foreach ($contentConfig as $field => $fieldConfig) {
                 $extractedTranslations = $this->extractFieldTranslations($fieldConfig, $seo[$field] ?? null);
-                if (null !== $extractedTranslations) {
+                if ($extractedTranslations instanceof Translation) {
                     $translations['_seo'][$field] = $extractedTranslations;
                 }
             }
@@ -151,7 +151,7 @@ class TranslatorExtractor
                         continue;
                     }
                     $extractedTranslations = $this->extractFieldTranslations($fieldConfig, $moduleData[$field] ?? null);
-                    if (null !== $extractedTranslations) {
+                    if ($extractedTranslations instanceof Translation) {
                         $translations[$field] = $extractedTranslations;
                     }
                 }

--- a/templates/admin/content/version_translations.bootstrap5.html.twig
+++ b/templates/admin/content/version_translations.bootstrap5.html.twig
@@ -16,23 +16,23 @@
                 href="{{ url('sfs_cms_admin_content_'~content_type~'_list') }}">{{ ('admin_'~content_type~'.list.breadcrumb')|trans }}</a>
     </li>
     <li class="breadcrumb-item"><a
-                href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':entity}) }}">{{ ('admin_'~content_type~'.read.breadcrumb')|trans({'%name%': entity.name}) }}</a>
+                href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':content_entity}) }}">{{ ('admin_'~content_type~'.read.breadcrumb')|trans({'%name%': content_entity.name}) }}</a>
     </li>
     <li class="breadcrumb-item active"
         aria-current="content">{{ ('admin_'~content_type~'.translations.breadcrumb')|trans({'%name%':content_entity.name}) }}</li>
 {% endblock breadcrums_content %}
 
 {% block content %}
-    {% include ['@content/'~content_type~'/admin/_content_title.html.twig', '@SfsCms/admin/content/_content_title.html.twig']  with {'current':'translations', 'content_type':content_type, 'content_entity':entity, 'version_entity': prev_version|default(false)} %}
-    {% include ['@content/'~content_type~'/admin/_content_tabs.html.twig', '@SfsCms/admin/content/_content_tabs.html.twig']  with {'current':'translations', 'content':content_entity, 'entity':version_entity} %}
+    {% include ['@content/'~content_type~'/admin/_content_title.html.twig', '@SfsCms/admin/content/_content_title.html.twig']  with {'current':'translations', 'content_type':content_type, 'content_entity':content_entity, 'version_entity': prev_version|default(false)} %}
+    {% include ['@content/'~content_type~'/admin/_content_tabs.html.twig', '@SfsCms/admin/content/_content_tabs.html.twig']  with {'current':'translations', 'content':content_entity, 'version_entity': version_entity} %}
 
     <div class="container-fluid mb-3">
         <div class="row">
             <div class="col">
                 <div class="float-end">
-                    {% if not content_config.admin.version_translations_import.is_granted or is_granted(content_config.admin.version_translations_import.is_granted, entity) %}
+                    {% if not content_config.admin.version_translations_import.is_granted or is_granted(content_config.admin.version_translations_import.is_granted, content_entity) %}
                         <a class="btn btn-outline-secondary"
-                           href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_import', {'content':entity.id, 'back':'translations', 'version':prev_version.id}) }}">
+                           href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_import', {'content':content_entity.id, 'back':'translations', 'version':prev_version.id}) }}">
                             <i class="bi bi-upload"></i>
                             {{ ('admin_'~content_type~'.translations.actions.import_translations.link')|trans }}
                         </a>
@@ -43,7 +43,7 @@
                         </a>
                     {% endif %}
 
-                    {% if not content_config.admin.version_translations_export.is_granted or is_granted(content_config.admin.version_translations_export.is_granted, entity) %}
+                    {% if not content_config.admin.version_translations_export.is_granted or is_granted(content_config.admin.version_translations_export.is_granted, content_entity) %}
                         {% if content_config.admin.version_translations_export.formats|length > 1 %}
                             <div class="btn-group">
                                 <button type="button" class="btn btn-outline-secondary dropdown-toggle" title="Export"
@@ -54,7 +54,7 @@
                                 <ul class="dropdown-menu dropdown-menu-end">
                                     {% for format in content_config.admin.version_translations_export.formats %}
                                         <li><a class="dropdown-item"
-                                               href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export_all', {'content':entity.id, 'back':'translations', 'version':prev_version.id, 'format': format}) }}">{{ ('admin_page.translations.export.formats.'~format)|trans }}</a>
+                                               href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export_all', {'content':content_entity.id, 'back':'translations', 'version':prev_version.id, 'format': format}) }}">{{ ('admin_page.translations.export.formats.'~format)|trans }}</a>
                                         </li>
                                     {% endfor %}
                                 </ul>
@@ -62,7 +62,7 @@
                         {% else %}
                             {% set format = content_config.admin.version_translations_export.formats|first %}
                             <a class="btn btn-outline-secondary"
-                               href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export_all', {'content':entity.id, 'back':'translations', 'version':prev_version.id, 'format': format}) }}"
+                               href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export_all', {'content':content_entity.id, 'back':'translations', 'version':prev_version.id, 'format': format}) }}"
                                title="{{ ('admin_page.translations.export.formats.'~format)|trans }}">
                                 <i class="bi bi-download"></i>
                                 {{ ('admin_'~content_type~'.translations.actions.export_translations.link')|trans }}
@@ -149,7 +149,7 @@
                                         </span>
                                     {% endif %}
 
-                                    {% if not content_config.admin.version_translations_export.is_granted or is_granted(content_config.admin.version_translations_export.is_granted, entity) %}
+                                    {% if not content_config.admin.version_translations_export.is_granted or is_granted(content_config.admin.version_translations_export.is_granted, content_entity) %}
                                         {% if content_config.admin.version_translations_export.formats|length > 1 %}
                                             <div class="btn-group">
                                                 <button type="button" class="btn btn-link dropdown-toggle"
@@ -160,7 +160,7 @@
                                                 <ul class="dropdown-menu dropdown-menu-end">
                                                     {% for format in content_config.admin.version_translations_export.formats %}
                                                         <li><a class="dropdown-item"
-                                                               href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export', {'content':entity.id, 'back':'translations', 'version':prev_version.id, 'target':locale, 'format': format}) }}">{{ ('admin_page.translations.export.formats.'~format)|trans }}</a>
+                                                               href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export', {'content':content_entity.id, 'back':'translations', 'version':prev_version.id, 'target':locale, 'format': format}) }}">{{ ('admin_page.translations.export.formats.'~format)|trans }}</a>
                                                         </li>
                                                     {% endfor %}
                                                 </ul>
@@ -168,7 +168,7 @@
                                         {% else %}
                                             {% set format = content_config.admin.version_translations_export.formats|first %}
                                             <a class="btn btn-link float-end p-0"
-                                               href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export', {'content':entity.id, 'back':'translations', 'version':prev_version.id, 'target':locale, 'format': format}) }}"
+                                               href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export', {'content':content_entity.id, 'back':'translations', 'version':prev_version.id, 'target':locale, 'format': format}) }}"
                                                title="{{ ('admin_page.translations.export.formats.'~format)|trans }}">
                                                 <i class="bi bi-download"></i>
                                             </a>
@@ -227,7 +227,7 @@
                 {{ form_rest(form) }}
 
                 <div class="d-flex justify-content-end align-items-center">
-                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':entity.id}) }}"
+                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':content_entity.id}) }}"
                        class="btn btn-outline-secondary">{{ ('admin_'~content_type~'.translations.actions.cancel.button')|trans }}</a>
                     <input type="submit" value="{{ ('admin_'~content_type~'.translations.actions.save.button')|trans }}"
                            class="btn btn-primary ms-3"/>

--- a/templates/admin/content/version_translations.semantic-ui.html.twig
+++ b/templates/admin/content/version_translations.semantic-ui.html.twig
@@ -19,19 +19,19 @@
     <a class="section"
        href="{{ url('sfs_cms_admin_content_'~content_type~'_list') }}">{{ ('admin_'~content_type~'.list.breadcrumb')|trans }}</a>
     <i class="right chevron icon divider"></i>
-    <a class="section" href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':entity.id}) }}">{{ ('admin_'~content_type~'.read.breadcrumb')|trans({'%name%': entity.name}) }}</a>
+    <a class="section" href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':content_entity.id}) }}">{{ ('admin_'~content_type~'.read.breadcrumb')|trans({'%name%': content_entity.name}) }}</a>
     <i class="right chevron icon divider"></i>
     <a class="section active">{{ ('admin_'~content_type~'.translations.breadcrumb')|trans({'%name%':content_entity.name}) }}</a>
 {% endblock breadcrums_content %}
 
 {% block content %}
-    {% include ['@content/'~content_type~'/admin/_content_tabs.html.twig', '@SfsCms/admin/content/_content_tabs.html.twig']  with {'current':'translations', 'content':content_entity, 'entity':version_entity} %}
+    {% include ['@content/'~content_type~'/admin/_content_tabs.html.twig', '@SfsCms/admin/content/_content_tabs.html.twig']  with {'current':'translations', 'content':content_entity, 'version_entity': version_entity} %}
     <div class="ui bottom attached active tab segment">
         <div class="ui right aligned grid clearing" style="margin-bottom: 0">
             <div class="ui buttons column">
-                {% if not content_config.admin.version_translations_import.is_granted or is_granted(content_config.admin.version_translations_import.is_granted, entity) %}
+                {% if not content_config.admin.version_translations_import.is_granted or is_granted(content_config.admin.version_translations_import.is_granted, content_entity) %}
                     <a class="ui blue labeled icon button"
-                       href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_import', {'content':entity.id, 'back':'translations', 'version':prev_version.id}) }}">
+                       href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_import', {'content':content_entity.id, 'back':'translations', 'version':prev_version.id}) }}">
                         <i class="icon upload"></i>
                         {{ ('admin_'~content_type~'.translations.actions.import_translations.link')|trans }}
                     </a>
@@ -43,7 +43,7 @@
                 {% endif %}
 
 
-                {% if not content_config.admin.version_translations_export.is_granted or is_granted(content_config.admin.version_translations_export.is_granted, entity) %}
+                {% if not content_config.admin.version_translations_export.is_granted or is_granted(content_config.admin.version_translations_export.is_granted, content_entity) %}
                     {% if content_config.admin.version_translations_export.formats|length > 1 %}
 {#                        <div class="btn-group">#}
 {#                            <button type="button" class="btn btn-outline-secondary dropdown-toggle" title="Export"#}
@@ -54,7 +54,7 @@
 {#                            <ul class="dropdown-menu dropdown-menu-end">#}
 {#                                {% for format in content_config.admin.version_translations_export.formats %}#}
 {#                                    <li><a class="dropdown-item"#}
-{#                                           href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export_all', {'content':entity.id, 'back':'translations', 'format': format, 'version':prev_version.id}))}}">{{ ('admin_page.translations.export.formats.'~format)|trans }}</a>#}
+{#                                           href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export_all', {'content':content_entity.id, 'back':'translations', 'format': format, 'version':prev_version.id}))}}">{{ ('admin_page.translations.export.formats.'~format)|trans }}</a>#}
 {#                                    </li>#}
 {#                                {% endfor %}#}
 {#                            </ul>#}
@@ -63,7 +63,7 @@
                     {% else %}
                         {% set format = content_config.admin.version_translations_export.formats|first %}
                         <a class="ui red labeled icon button"
-                           href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export_all', {'content':entity.id, 'back':'translations', 'format': format, 'version':prev_version.id}) }}"
+                           href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export_all', {'content':content_entity.id, 'back':'translations', 'format': format, 'version':prev_version.id}) }}"
                            title="{{ ('admin_page.translations.export.formats.'~format)|trans }}">
                             <i class="icon download"></i>
                             {{ ('admin_'~content_type~'.translations.actions.export_translations.link')|trans }}
@@ -133,7 +133,7 @@
                                 </span>
                             {% endif %}
 
-                            {% if not content_config.admin.version_translations_export.is_granted or is_granted(content_config.admin.version_translations_export.is_granted, entity) %}
+                            {% if not content_config.admin.version_translations_export.is_granted or is_granted(content_config.admin.version_translations_export.is_granted, content_entity) %}
                                 {% if content_config.admin.version_translations_export.formats|length > 1 %}
 {#                                    <div class="btn-group">#}
 {#                                        <button type="button" class="btn btn-link dropdown-toggle"#}
@@ -144,7 +144,7 @@
 {#                                        <ul class="dropdown-menu dropdown-menu-end">#}
 {#                                            {% for format in content_config.admin.version_translations_export.formats %}#}
 {#                                                <li><a class="dropdown-item"#}
-{#                                                       href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export', {'content':entity.id, 'back':'translations', 'target':locale, 'format': format, 'version':prev_version.id}))}}">{{ ('admin_page.translations.export.formats.'~format)|trans }}</a>#}
+{#                                                       href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export', {'content':content_entity.id, 'back':'translations', 'target':locale, 'format': format, 'version':prev_version.id}))}}">{{ ('admin_page.translations.export.formats.'~format)|trans }}</a>#}
 {#                                                </li>#}
 {#                                            {% endfor %}#}
 {#                                        </ul>#}
@@ -153,7 +153,7 @@
                                 {% else %}
                                     {% set format = content_config.admin.version_translations_export.formats|first %}
                                     <a class="ui right floated icon button"
-                                       href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export', {'content':entity.id, 'back':'translations', 'target':locale, 'format': format, 'version':prev_version.id}) }}"
+                                       href="{{ url('sfs_cms_admin_content_'~content_type~'_translations_export', {'content':content_entity.id, 'back':'translations', 'target':locale, 'format': format, 'version':prev_version.id}) }}"
                                        title="{{ ('admin_page.translations.export.formats.'~format)|trans }}">
                                         <i class="icon download"></i>
                                     </a>
@@ -214,7 +214,7 @@
         <div class="ui hidden divider"></div>
         <div class="ui buttons">
             <button class="ui labeled icon primary button" type="submit"><i class="save icon"></i> {{ ('admin_'~content_type~'.translations.actions.save.button')|trans }}</button>
-            <a href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':entity.id}) }}" class="ui button">{{ ('admin_'~content_type~'.translations.actions.cancel.button')|trans }}</a>
+            <a href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':content_entity.id}) }}" class="ui button">{{ ('admin_'~content_type~'.translations.actions.cancel.button')|trans }}</a>
         </div>
         {{ form_end(form) }}
     </div>

--- a/templates/admin/content/version_translations_import.bootstrap5.html.twig
+++ b/templates/admin/content/version_translations_import.bootstrap5.html.twig
@@ -15,15 +15,15 @@
                 href="{{ url('sfs_cms_admin_content_'~content_type~'_list') }}">{{ ('admin_'~content_type~'.list.breadcrumb')|trans }}</a>
     </li>
     <li class="breadcrumb-item"><a
-                href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':entity.id}) }}">{{ ('admin_'~content_type~'.read.breadcrumb')|trans({'%name%': entity.name}) }}</a>
+                href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':content_entity.id}) }}">{{ ('admin_'~content_type~'.read.breadcrumb')|trans({'%name%': content_entity.name}) }}</a>
     </li>
     <li class="breadcrumb-item active"
         aria-current="content">{{ ('admin_'~content_type~'.translations_import.breadcrumb')|trans({'%name%':content_entity.name}) }}</li>
 {% endblock breadcrums_content %}
 
 {% block content %}
-    {% include ['@content/'~content_type~'/admin/_content_title.html.twig', '@SfsCms/admin/content/_content_title.html.twig']  with {'current':'translations', 'content_type':content_type, 'content_entity':entity, 'version_entity': prev_version|default(false)} %}
-    {% include ['@content/'~content_type~'/admin/_content_tabs.html.twig', '@SfsCms/admin/content/_content_tabs.html.twig']  with {'current':'translations', 'content':content_entity, 'entity':version_entity} %}
+    {% include ['@content/'~content_type~'/admin/_content_title.html.twig', '@SfsCms/admin/content/_content_title.html.twig']  with {'current':'translations', 'content_type':content_type, 'content_entity':content_entity, 'version_entity': prev_version|default(false)} %}
+    {% include ['@content/'~content_type~'/admin/_content_tabs.html.twig', '@SfsCms/admin/content/_content_tabs.html.twig']  with {'current':'translations', 'content':content_entity, 'version_entity': version_entity} %}
 
     <div class="container-fluid bg-white">
         <div class="row">
@@ -34,7 +34,7 @@
                 {{ form_rest(form) }}
 
                 <div class="d-flex justify-content-end align-items-center">
-                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_translations', {'content':entity.id}) }}"
+                    <a href="{{ url('sfs_cms_admin_content_'~content_type~'_translations', {'content':content_entity.id}) }}"
                        class="btn btn-outline-secondary">{{ ('admin_'~content_type~'.translations_import.actions.cancel.button')|trans }}</a>
                     <input type="submit" value="{{ ('admin_'~content_type~'.translations_import.actions.import.button')|trans }}"
                            class="btn btn-primary ms-3"/>

--- a/templates/admin/content/version_translations_import.semantic-ui.html.twig
+++ b/templates/admin/content/version_translations_import.semantic-ui.html.twig
@@ -19,13 +19,13 @@
        href="{{ url('sfs_cms_admin_content_'~content_type~'_list') }}">{{ ('admin_'~content_type~'.list.breadcrumb')|trans }}</a>
     <i class="right chevron icon divider"></i>
     <a class="section"
-       href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':entity.id}) }}">{{ ('admin_'~content_type~'.read.breadcrumb')|trans({'%name%': entity.name}) }}</a>
+       href="{{ url('sfs_cms_admin_content_'~content_type~'_details', {'content':content_entity.id}) }}">{{ ('admin_'~content_type~'.read.breadcrumb')|trans({'%name%': content_entity.name}) }}</a>
     <i class="right chevron icon divider"></i>
     <a class="section active">{{ ('admin_'~content_type~'.translations_import.breadcrumb')|trans({'%name%':content_entity.name}) }}</a>
 {% endblock breadcrums_content %}
 
 {% block content %}
-    {% include ['@content/'~content_type~'/admin/_content_tabs.html.twig', '@SfsCms/admin/content/_content_tabs.html.twig']  with {'current':'translations', 'content':content_entity, 'entity':version_entity} %}
+    {% include ['@content/'~content_type~'/admin/_content_tabs.html.twig', '@SfsCms/admin/content/_content_tabs.html.twig']  with {'current':'translations', 'content':content_entity, 'version_entity': version_entity} %}
 
     <div class="ui bottom attached active tab segment">
         {{ form_start(form,{'attr':{'class':'ui form clearing'}}) }}
@@ -36,7 +36,7 @@
             <button class="ui labeled icon primary button" type="submit"><i
                         class="save icon"></i> {{ ('admin_'~content_type~'.translations_import.actions.import.button')|trans }}
             </button>
-            <a href="{{ url('sfs_cms_admin_content_'~content_type~'_translations', {'content':entity.id}) }}"
+            <a href="{{ url('sfs_cms_admin_content_'~content_type~'_translations', {'content':content_entity.id}) }}"
                class="ui button">{{ ('admin_'~content_type~'.translations_import.actions.cancel.button')|trans }}</a>
         </div>
 

--- a/templates/bundles/SfsCmsBundle/admin/content/_read_translations.bootstrap5.html.twig
+++ b/templates/bundles/SfsCmsBundle/admin/content/_read_translations.bootstrap5.html.twig
@@ -6,8 +6,8 @@
     {% block title %}
         <h5 class="border-bottom border-1 border-light pb-2 mb-3 d-flex align-items-center justify-content-between gap-2">
             <span>{{ title }}</span>
-            {% if not content_config.admin.version_translations.is_granted or is_granted(content_config.admin.version_translations.is_granted, entity) %}
-                <a class="btn btn-sm btn-outline-secondary flex-shrink-0" href="{{ url('sfs_cms_admin_content_'~content_type~'_translations', {'content':entity.id}) }}">{{ ('admin_'~content_type~'.read.translations.edit.link')|trans }} <i class="bi bi-translate"></i></a>
+            {% if not content_config.admin.version_translations.is_granted or is_granted(content_config.admin.version_translations.is_granted, content_entity) %}
+                <a class="btn btn-sm btn-outline-secondary flex-shrink-0" href="{{ url('sfs_cms_admin_content_'~content_type~'_translations', {'content':content_entity.id}) }}">{{ ('admin_'~content_type~'.read.translations.edit.link')|trans }} <i class="bi bi-translate"></i></a>
             {% else %}
                 <a class="btn btn-sm btn-outline-secondary flex-shrink-0 disabled">{{ ('admin_'~content_type~'.read.translations.edit.link')|trans }} <i class="bi bi-translate"></i></a>
             {% endif %}
@@ -15,12 +15,12 @@
     {% endblock %}
 
     {% block content %}
-        {% set stats = entity.lastVersion.getMetaField('translations_statistics')|default([]) %}
+        {% set stats = content_entity.lastVersion.getMetaField('translations_statistics')|default([]) %}
 
         <p class="d-flex mb-2">
             {#<span class="pe-2">Default language</span>#}
-            {#<strong>{{ entity.defaultLocale }}</strong>#}
-            <span>{{ ('locale.'~entity.defaultLocale)|trans({}, 'sfs_cms_admin') }}</span>
+            {#<strong>{{ content_entity.defaultLocale }}</strong>#}
+            <span>{{ ('locale.'~content_entity.defaultLocale)|trans({}, 'sfs_cms_admin') }}</span>
         </p>
 
         <div class="progress mb-2" role="progressbar" aria-label="Example with label" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">

--- a/templates/bundles/SfsCmsBundle/admin/content/_read_translations.semantic-ui.html.twig
+++ b/templates/bundles/SfsCmsBundle/admin/content/_read_translations.semantic-ui.html.twig
@@ -4,8 +4,8 @@
     {% trans_default_domain 'sfs_cms_contents' %}
 
     {% block title %}
-        {% if not content_config.admin.version_translations.is_granted or is_granted(content_config.admin.version_translations.is_granted, entity) %}
-            <a class="ui mini basic button right floated" href="{{ url('sfs_cms_admin_content_'~content_type~'_translations', {'content':entity.id}) }}">
+        {% if not content_config.admin.version_translations.is_granted or is_granted(content_config.admin.version_translations.is_granted, content_entity) %}
+            <a class="ui mini basic button right floated" href="{{ url('sfs_cms_admin_content_'~content_type~'_translations', {'content':content_entity.id}) }}">
                 <i class="language icon"></i> {{ ('admin_'~content_type~'.read.translations.edit.link')|trans }}
             </a>
         {% else %}
@@ -17,12 +17,12 @@
     {% endblock %}
 
     {% block content %}
-        {% set stats = entity.lastVersion.getMetaField('translations_statistics')|default([]) %}
+        {% set stats = content_entity.lastVersion.getMetaField('translations_statistics')|default([]) %}
 
         <div class="ui horizontal list" style="margin-bottom: 1em;">
             <div class="item">
                 <div class="content">
-                    <div class="header">{{ ('locale.'~entity.defaultLocale)|trans({}, 'sfs_cms_admin') }}</div>
+                    <div class="header">{{ ('locale.'~content_entity.defaultLocale)|trans({}, 'sfs_cms_admin') }}</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Summary:\n- Rename content admin Twig context from entity to content_entity.\n- Keep version context explicit in translation views.\n- Update RenderErrorException namespace import.\n\nValidation:\n- lint:twig passed for affected templates from the consuming app.